### PR TITLE
Update supported PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,36 +12,24 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.2
       env:
         - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
+    - php: 7.2
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.2
+    - php: 7.3
       env:
         - DEPS=latest
-    - php: 7.3
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7.3
+    - php: 7.4
       env:
         - DEPS=latest
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "laminas/laminas-code": "^2.5 || ^3.0",
         "laminas/laminas-stdlib": "^2.5 || ^3.0",
         "laminas/laminas-zendframework-bridge": "^1.0"


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This PR

- bumps required PHP version in composer.json to ^7.2,
- drops no longer maintained PHP versions in Travis CI build matrix and
- adds PHP 7.4 support in Travis CI build matrix.
