### PR TITLE
Migrate codebase to use typed properties and PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,26 +12,14 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.3
-      env:
-        - DEPS=lowest
-    - php: 7.3
-      env:
-        - DEPS=latest
-    - php: 7.4
-      env:
-        - DEPS=lowest
-    - php: 7.4
-      env:
-        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,14 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4",
         "laminas/laminas-code": "^3.4.1",
         "laminas/laminas-stdlib": "^3.2.1"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.0.0",
-        "phpunit/phpunit": "^8.5.2"
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/AbstractServer.php
+++ b/src/AbstractServer.php
@@ -17,11 +17,9 @@ use function is_object;
 
 abstract class AbstractServer implements ServerInterface
 {
-    /** @var bool */
-    protected $overwriteExistingMethods = false;
+    protected bool $overwriteExistingMethods = false;
 
-    /** @var Definition */
-    protected $table;
+    protected Definition $table;
 
     public function __construct()
     {

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -31,7 +31,7 @@ use const E_NOTICE;
 class Cache
 {
     /** @var string[] */
-    protected static $skipMethods = [];
+    protected static array $skipMethods = [];
 
     /**
      * Cache a file containing the dispatch list.

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -27,10 +27,9 @@ use function sprintf;
 class Definition implements Countable, Iterator
 {
     /** @var Method\Definition[] */
-    protected $methods = [];
+    protected array $methods = [];
 
-    /** @var bool */
-    protected $overwriteExistingMethods = false;
+    protected bool $overwriteExistingMethods = false;
 
     public function __construct(?array $methods = null)
     {

--- a/src/Method/Callback.php
+++ b/src/Method/Callback.php
@@ -23,8 +23,7 @@ use function ucfirst;
 
 class Callback
 {
-    /** @var string */
-    protected $class;
+    protected ?string $class = null;
 
     /**
      * Function name or callable for function callback
@@ -33,18 +32,12 @@ class Callback
      */
     protected $function;
 
-    /** @var string */
-    protected $method;
+    protected ?string $method = null;
 
-    /** @var null|string */
-    protected $type;
+    protected ?string $type = null;
 
-    /**
-     * Valid callback types
-     *
-     * @var array
-     */
-    protected $types = ['function', 'static', 'instance'];
+    /** Valid callback types */
+    protected array $types = ['function', 'static', 'instance'];
 
     public function __construct(?array $options = null)
     {

--- a/src/Method/Definition.php
+++ b/src/Method/Definition.php
@@ -21,20 +21,16 @@ class Definition
     /** @var null|Callback */
     protected $callback;
 
-    /** @var array */
-    protected $invokeArguments = [];
+    protected array $invokeArguments = [];
 
-    /** @var string */
-    protected $methodHelp = '';
+    protected string $methodHelp = '';
 
-    /** @var null|string */
-    protected $name;
+    protected ?string $name = null;
 
-    /** @var null|object */
-    protected $object;
+    protected ?object $object = null;
 
     /** @var Prototype[] */
-    protected $prototypes = [];
+    protected array $prototypes = [];
 
     public function __construct(?array $options = null)
     {

--- a/src/Method/Parameter.php
+++ b/src/Method/Parameter.php
@@ -19,17 +19,13 @@ class Parameter
     /** @var mixed */
     protected $defaultValue;
 
-    /** @var string */
-    protected $description = '';
+    protected string $description = '';
 
-    /** @var null|string */
-    protected $name;
+    protected ?string $name = null;
 
-    /** @var bool */
-    protected $optional = false;
+    protected bool $optional = false;
 
-    /** @var string */
-    protected $type = 'mixed';
+    protected string $type = 'mixed';
 
     public function __construct(?array $options = null)
     {

--- a/src/Method/Prototype.php
+++ b/src/Method/Prototype.php
@@ -20,18 +20,12 @@ use function ucfirst;
 
 class Prototype
 {
-    /** @var string */
-    protected $returnType = 'void';
+    protected string $returnType = 'void';
 
-    /**
-     * Map parameter names to parameter index
-     *
-     * @var array
-     */
-    protected $parameterNameMap = [];
+    /** Map parameter names to parameter index */
+    protected array $parameterNameMap = [];
 
-    /** @var array */
-    protected $parameters = [];
+    protected array $parameters = [];
 
     public function __construct(?array $options = null)
     {

--- a/src/Reflection.php
+++ b/src/Reflection.php
@@ -59,7 +59,7 @@ class Reflection
      * Perform function reflection to create dispatch signatures
      *
      * Creates dispatch prototypes for a function. It returns a
-     * {@link Laminas\Server\Reflection\FunctionReflection} object.
+     * {@link \Laminas\Server\Reflection\FunctionReflection} object.
      *
      * If extra arguments should be passed to the dispatchable function, these
      * may be provided as an array to $argv.

--- a/src/Reflection/AbstractFunction.php
+++ b/src/Reflection/AbstractFunction.php
@@ -37,56 +37,34 @@ use function preg_match;
  */
 abstract class AbstractFunction
 {
-    /** @var ReflectionFunctionAbstract */
-    protected $reflection;
+    protected ?ReflectionFunctionAbstract $reflection = null;
 
-    /**
-     * Additional arguments to pass to method on invocation
-     *
-     * @var array
-     */
-    protected $argv = [];
+    /** Additional arguments to pass to method on invocation */
+    protected array $argv = [];
 
     /**
      * Used to store extra configuration for the method (typically done by the
      * server class, e.g., to indicate whether or not to instantiate a class).
      * Associative array; access is as properties via {@link __get()} and
      * {@link __set()}
-     *
-     * @var array
      */
-    protected $config = [];
+    protected array $config = [];
 
-    /**
-     * Declaring class (needed for when serialization occurs)
-     *
-     * @var string
-     */
-    protected $class;
+    /** Declaring class (needed for when serialization occurs) */
+    protected string $class;
 
-    /**
-     * Function name (needed for serialization)
-     *
-     * @var string
-     */
-    protected $name;
+    /** Function name (needed for serialization) */
+    protected string $name;
 
-    /**
-     * Function/method description
-     *
-     * @var string
-     */
-    protected $description = '';
+    /** Function/method description */
+    protected string $description = '';
 
-    /**
-     * Namespace with which to prefix function/method name
-     *
-     * @var null|string
-     */
-    protected $namespace;
+    /** Namespace with which to prefix function/method name */
+    protected ?string $namespace = null;
 
-    protected $prototypes = [];
+    protected array $prototypes = [];
 
+    /** @var string|bool */
     protected $docComment = '';
 
     protected $return;

--- a/src/Reflection/Node.php
+++ b/src/Reflection/Node.php
@@ -19,10 +19,9 @@ class Node
     protected $value;
 
     /** @var self[] */
-    protected $children = [];
+    protected array $children = [];
 
-    /** @var null|self */
-    protected $parent;
+    protected ?Node $parent = null;
 
     /**
      * @param mixed $value

--- a/src/Reflection/Prototype.php
+++ b/src/Reflection/Prototype.php
@@ -13,10 +13,9 @@ namespace Laminas\Server\Reflection;
 class Prototype
 {
     /** @var ReflectionParameter[] */
-    protected $params;
+    protected array $params;
 
-    /** @var ReflectionReturnValue */
-    private $return;
+    private ReflectionReturnValue $return;
 
     /**
      * @param ReflectionParameter[] $params

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -29,26 +29,20 @@ class ReflectionClass
     /**
      * Optional configuration parameters; accessible via {@link __get} and
      * {@link __set()}
-     *
-     * @var array
      */
-    protected $config = [];
+    protected array $config = [];
 
     /** @var ReflectionMethod[] */
-    protected $methods = [];
+    protected array $methods = [];
 
-    /** @var null|string */
-    protected $namespace;
+    protected ?string $namespace = null;
 
-    /** @var PhpReflectionClass */
-    protected $reflection;
+    protected PhpReflectionClass $reflection;
 
     /**
      * Reflection class name (needed for serialization)
-     *
-     * @var string
      */
-    protected $name;
+    protected string $name;
 
     /**
      * Constructor

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -22,7 +22,7 @@ use function substr;
  * Class/Object reflection
  *
  * Proxies calls to a ReflectionClass object, and decorates getMethods() by
- * creating its own list of {@link Laminas\Server\Reflection\ReflectionMethod}s.
+ * creating its own list of {@link \Laminas\Server\Reflection\ReflectionMethod}s.
  */
 class ReflectionClass
 {
@@ -48,7 +48,7 @@ class ReflectionClass
      * Constructor
      *
      * Create array of dispatchable methods, each a
-     * {@link Laminas\Server\Reflection\ReflectionMethod}. Sets reflection object property.
+     * {@link \Laminas\Server\Reflection\ReflectionMethod}. Sets reflection object property.
      */
     public function __construct(PhpReflectionClass $reflection, ?string $namespace = null, array $argv = [])
     {

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -31,17 +31,13 @@ class ReflectionMethod extends AbstractFunction
 
     /**
      * Parent class name
-     *
-     * @var string
      */
-    protected $class;
+    protected string $class;
 
     /**
      * Parent class reflection
-     *
-     * @var ReflectionClass
      */
-    protected $classReflection;
+    protected ReflectionClass $classReflection;
 
     public function __construct(
         ReflectionClass $class,

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -126,11 +126,8 @@ class ReflectionMethod extends AbstractFunction
         }
 
         $normalizedDocCommentList = array_map(
-            function ($docComment) {
-                $docComment = str_replace('/**', '', $docComment);
-                $docComment = str_replace('*/', '', $docComment);
-
-                return $docComment;
+            static function ($docComment) {
+                return str_replace(['/**', '*/'], '', $docComment);
             },
             $docCommentList
         );

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -17,28 +17,24 @@ use function method_exists;
 
 class ReflectionParameter
 {
-    /** @var PhpReflectionParameter */
-    protected $reflection;
+    protected PhpReflectionParameter $reflection;
 
-    /** @var int */
-    protected $position;
+    protected ?int $position = null;
 
-    /** @var string */
-    protected $type;
+    protected string $type;
 
-    /** @var null|string */
-    protected $description;
+    protected ?string $description = null;
 
     /**
      * Parameter name (needed for serialization)
-     *
-     * @var string
      */
-    protected $name;
+    protected string $name;
 
     /**
      * Declaring function name (needed for serialization)
      *
+     * @todo Figure out correct type for $functionName. It is set to either a
+     *       string or array of strings in the constructor.
      * @var string
      */
     protected $functionName;

--- a/src/Reflection/ReflectionReturnValue.php
+++ b/src/Reflection/ReflectionReturnValue.php
@@ -17,11 +17,9 @@ namespace Laminas\Server\Reflection;
  */
 class ReflectionReturnValue
 {
-    /** @var string */
-    protected $type;
+    protected string $type;
 
-    /** @var string */
-    protected $description;
+    protected string $description;
 
     public function __construct(string $type = 'mixed', string $description = '')
     {

--- a/test/CacheTest.php
+++ b/test/CacheTest.php
@@ -16,6 +16,7 @@ use Laminas\Server\Method\Callback;
 use Laminas\Server\Method\Definition as MethodDefinition;
 use Laminas\Server\ServerInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionProperty;
 
 use function file_get_contents;
@@ -26,6 +27,8 @@ use function unserialize;
 
 class CacheTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var string */
     private $cacheFile;
 

--- a/test/CacheTest.php
+++ b/test/CacheTest.php
@@ -53,7 +53,7 @@ class CacheTest extends TestCase
         $server = $this->createStub(ServerInterface::class);
         $result = Cache::save('~/non-existent-file.tmp', $server);
 
-        $this->assertFalse($result);
+        self::assertFalse($result);
     }
 
     public function testCacheCanAcceptAServerReturningAnArrayOfFunctions(): void
@@ -68,11 +68,11 @@ class CacheTest extends TestCase
 
         $this->cacheFile = tempnam(sys_get_temp_dir(), 'zs');
 
-        $this->assertTrue(Cache::save($this->cacheFile, $server->reveal()));
+        self::assertTrue(Cache::save($this->cacheFile, $server->reveal()));
 
         $data = file_get_contents($this->cacheFile);
         $data = unserialize($data);
-        $this->assertEquals($functions, $data);
+        self::assertEquals($functions, $data);
     }
 
     public function testCacheCanAcceptAServerReturningADefinition(): void
@@ -94,11 +94,11 @@ class CacheTest extends TestCase
 
         $this->cacheFile = tempnam(sys_get_temp_dir(), 'zs');
 
-        $this->assertTrue(Cache::save($this->cacheFile, $server->reveal()));
+        self::assertTrue(Cache::save($this->cacheFile, $server->reveal()));
 
         $data = file_get_contents($this->cacheFile);
         $data = unserialize($data);
-        $this->assertEquals($definition, $data);
+        self::assertEquals($definition, $data);
     }
 
     public function testCacheSkipsMethodsWhenGivenAnArrayOfFunctions(): void
@@ -115,7 +115,7 @@ class CacheTest extends TestCase
 
         $this->cacheFile = tempnam(sys_get_temp_dir(), 'zs');
 
-        $this->assertTrue(Cache::save($this->cacheFile, $server->reveal()));
+        self::assertTrue(Cache::save($this->cacheFile, $server->reveal()));
 
         $data = file_get_contents($this->cacheFile);
         $data = unserialize($data);
@@ -123,7 +123,7 @@ class CacheTest extends TestCase
         $expected = $functions;
         unset($expected['substr']);
 
-        $this->assertEquals($expected, $data);
+        self::assertEquals($expected, $data);
     }
 
     public function testCacheSkipsMethodsWhenGivenADefinition(): void
@@ -147,7 +147,7 @@ class CacheTest extends TestCase
 
         $this->cacheFile = tempnam(sys_get_temp_dir(), 'zs');
 
-        $this->assertTrue(Cache::save($this->cacheFile, $server->reveal()));
+        self::assertTrue(Cache::save($this->cacheFile, $server->reveal()));
 
         $data = file_get_contents($this->cacheFile);
         $data = unserialize($data);
@@ -159,7 +159,7 @@ class CacheTest extends TestCase
             $actual[] = $method->getName();
         }
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function testGetNonExistentFileReturnsFalse(): void
@@ -167,7 +167,7 @@ class CacheTest extends TestCase
         $server = $this->createStub(ServerInterface::class);
         $result = Cache::get('~/non-existent-file.tmp', $server);
 
-        $this->assertFalse($result);
+        self::assertFalse($result);
     }
 
     public function testDeleteNonExistentFileReturnsFalse(): void
@@ -175,6 +175,6 @@ class CacheTest extends TestCase
         $server = $this->createStub(ServerInterface::class);
         $result = Cache::delete('~/non-existent-file.tmp', $server);
 
-        $this->assertFalse($result);
+        self::assertFalse($result);
     }
 }

--- a/test/CacheTest.php
+++ b/test/CacheTest.php
@@ -29,8 +29,7 @@ class CacheTest extends TestCase
 {
     use ProphecyTrait;
 
-    /** @var string */
-    private $cacheFile;
+    private ?string $cacheFile = null;
 
     protected function tearDown(): void
     {

--- a/test/DefinitionTest.php
+++ b/test/DefinitionTest.php
@@ -30,8 +30,8 @@ class DefinitionTest extends TestCase
     public function testMethodsShouldBeEmptyArrayByDefault(): void
     {
         $methods = $this->definition->getMethods();
-        $this->assertIsArray($methods);
-        $this->assertEmpty($methods);
+        self::assertIsArray($methods);
+        self::assertEmpty($methods);
     }
 
     public function testDefinitionShouldAllowAddingSingleMethods(): void
@@ -39,9 +39,9 @@ class DefinitionTest extends TestCase
         $method = new Method\Definition(['name' => 'foo']);
         $this->definition->addMethod($method);
         $methods = $this->definition->getMethods();
-        $this->assertCount(1, $methods);
-        $this->assertSame($method, $methods['foo']);
-        $this->assertSame($method, $this->definition->getMethod('foo'));
+        self::assertCount(1, $methods);
+        self::assertSame($method, $methods['foo']);
+        self::assertSame($method, $this->definition->getMethod('foo'));
     }
 
     public function testConstructorNumericKeyWillBeReplacedByMethodName(): void
@@ -49,8 +49,8 @@ class DefinitionTest extends TestCase
         $method     = new Method\Definition(['name' => 'foo']);
         $definition = new Server\Definition(['100' => $method]);
 
-        $this->assertCount(1, $definition);
-        $this->assertSame($method, $definition->getMethod('foo'));
+        self::assertCount(1, $definition);
+        self::assertSame($method, $definition->getMethod('foo'));
     }
 
     public function testAddMethodNumericKeyWillBeReplacedByMethodName(): void
@@ -59,8 +59,8 @@ class DefinitionTest extends TestCase
         $definition = new Server\Definition();
         $definition->addMethod($method, '100');
 
-        $this->assertCount(1, $definition);
-        $this->assertSame($method, $definition->getMethod('foo'));
+        self::assertCount(1, $definition);
+        self::assertSame($method, $definition->getMethod('foo'));
     }
 
     public function testDefinitionShouldAllowAddingMultipleMethods(): void
@@ -69,11 +69,11 @@ class DefinitionTest extends TestCase
         $method2 = new Method\Definition(['name' => 'bar']);
         $this->definition->addMethods([$method1, $method2]);
         $methods = $this->definition->getMethods();
-        $this->assertCount(2, $methods);
-        $this->assertSame($method1, $methods['foo']);
-        $this->assertSame($method1, $this->definition->getMethod('foo'));
-        $this->assertSame($method2, $methods['bar']);
-        $this->assertSame($method2, $this->definition->getMethod('bar'));
+        self::assertCount(2, $methods);
+        self::assertSame($method1, $methods['foo']);
+        self::assertSame($method1, $this->definition->getMethod('foo'));
+        self::assertSame($method2, $methods['bar']);
+        self::assertSame($method2, $this->definition->getMethod('bar'));
     }
 
     public function testSetMethodsShouldOverwriteExistingMethods(): void
@@ -82,29 +82,29 @@ class DefinitionTest extends TestCase
         $method1 = new Method\Definition(['name' => 'foo']);
         $method2 = new Method\Definition(['name' => 'bar']);
         $methods = [$method1, $method2];
-        $this->assertNotEquals($methods, $this->definition->getMethods());
+        self::assertNotEquals($methods, $this->definition->getMethods());
         $this->definition->setMethods($methods);
         $test = $this->definition->getMethods();
-        $this->assertEquals(array_values($methods), array_values($test));
+        self::assertEquals(array_values($methods), array_values($test));
     }
 
     public function testHasMethodShouldReturnFalseWhenMethodNotRegisteredWithDefinition(): void
     {
-        $this->assertFalse($this->definition->hasMethod('foo'));
+        self::assertFalse($this->definition->hasMethod('foo'));
     }
 
     public function testHasMethodShouldReturnTrueWhenMethodRegisteredWithDefinition(): void
     {
         $this->testDefinitionShouldAllowAddingMultipleMethods();
-        $this->assertTrue($this->definition->hasMethod('foo'));
+        self::assertTrue($this->definition->hasMethod('foo'));
     }
 
     public function testDefinitionShouldAllowRemovingIndividualMethods(): void
     {
         $this->testDefinitionShouldAllowAddingMultipleMethods();
-        $this->assertTrue($this->definition->hasMethod('foo'));
+        self::assertTrue($this->definition->hasMethod('foo'));
         $this->definition->removeMethod('foo');
-        $this->assertFalse($this->definition->hasMethod('foo'));
+        self::assertFalse($this->definition->hasMethod('foo'));
     }
 
     public function testDefinitionShouldAllowClearingAllMethods(): void
@@ -112,7 +112,7 @@ class DefinitionTest extends TestCase
         $this->testDefinitionShouldAllowAddingMultipleMethods();
         $this->definition->clearMethods();
         $test = $this->definition->getMethods();
-        $this->assertEmpty($test);
+        self::assertEmpty($test);
     }
 
     public function testDefinitionShouldSerializeToArray(): void
@@ -135,12 +135,12 @@ class DefinitionTest extends TestCase
         $definition = new Server\Definition();
         $definition->addMethod($method);
         $test = $definition->toArray();
-        $this->assertCount(1, $test);
+        self::assertCount(1, $test);
         $test = array_shift($test);
-        $this->assertEquals($method['name'], $test['name']);
-        $this->assertEquals($method['methodHelp'], $test['methodHelp']);
-        $this->assertEquals($method['invokeArguments'], $test['invokeArguments']);
-        $this->assertEquals($method['prototypes'][0]['returnType'], $test['prototypes'][0]['returnType']);
+        self::assertEquals($method['name'], $test['name']);
+        self::assertEquals($method['methodHelp'], $test['methodHelp']);
+        self::assertEquals($method['invokeArguments'], $test['invokeArguments']);
+        self::assertEquals($method['prototypes'][0]['returnType'], $test['prototypes'][0]['returnType']);
     }
 
     public function testPassingOptionsToConstructorShouldSetObjectState(): void
@@ -163,11 +163,11 @@ class DefinitionTest extends TestCase
         $options    = [$method];
         $definition = new Server\Definition($options);
         $test       = $definition->toArray();
-        $this->assertCount(1, $test);
+        self::assertCount(1, $test);
         $test = array_shift($test);
-        $this->assertEquals($method['name'], $test['name']);
-        $this->assertEquals($method['methodHelp'], $test['methodHelp']);
-        $this->assertEquals($method['invokeArguments'], $test['invokeArguments']);
-        $this->assertEquals($method['prototypes'][0]['returnType'], $test['prototypes'][0]['returnType']);
+        self::assertEquals($method['name'], $test['name']);
+        self::assertEquals($method['methodHelp'], $test['methodHelp']);
+        self::assertEquals($method['invokeArguments'], $test['invokeArguments']);
+        self::assertEquals($method['prototypes'][0]['returnType'], $test['prototypes'][0]['returnType']);
     }
 }

--- a/test/DefinitionTest.php
+++ b/test/DefinitionTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Server;
 
-use Laminas\Server;
+use Laminas\Server\Definition;
 use Laminas\Server\Method;
 use PHPUnit\Framework\TestCase;
 
@@ -19,12 +19,11 @@ use function array_values;
 
 class DefinitionTest extends TestCase
 {
-    /** @var Server\Definition */
-    private $definition;
+    private Definition $definition;
 
     protected function setUp(): void
     {
-        $this->definition = new Server\Definition();
+        $this->definition = new Definition();
     }
 
     public function testMethodsShouldBeEmptyArrayByDefault(): void
@@ -47,7 +46,7 @@ class DefinitionTest extends TestCase
     public function testConstructorNumericKeyWillBeReplacedByMethodName(): void
     {
         $method     = new Method\Definition(['name' => 'foo']);
-        $definition = new Server\Definition(['100' => $method]);
+        $definition = new Definition(['100' => $method]);
 
         self::assertCount(1, $definition);
         self::assertSame($method, $definition->getMethod('foo'));
@@ -56,7 +55,7 @@ class DefinitionTest extends TestCase
     public function testAddMethodNumericKeyWillBeReplacedByMethodName(): void
     {
         $method     = new Method\Definition(['name' => 'foo']);
-        $definition = new Server\Definition();
+        $definition = new Definition();
         $definition->addMethod($method, '100');
 
         self::assertCount(1, $definition);
@@ -132,7 +131,7 @@ class DefinitionTest extends TestCase
             'methodHelp'      => 'Foo Bar!',
             'invokeArguments' => ['foo'],
         ];
-        $definition = new Server\Definition();
+        $definition = new Definition();
         $definition->addMethod($method);
         $test = $definition->toArray();
         self::assertCount(1, $test);
@@ -161,7 +160,7 @@ class DefinitionTest extends TestCase
             'invokeArguments' => ['foo'],
         ];
         $options    = [$method];
-        $definition = new Server\Definition($options);
+        $definition = new Definition($options);
         $test       = $definition->toArray();
         self::assertCount(1, $test);
         $test = array_shift($test);

--- a/test/Method/CallbackTest.php
+++ b/test/Method/CallbackTest.php
@@ -11,17 +11,16 @@ declare(strict_types=1);
 namespace LaminasTest\Server\Method;
 
 use Laminas\Server\Exception\InvalidArgumentException;
-use Laminas\Server\Method;
+use Laminas\Server\Method\Callback;
 use PHPUnit\Framework\TestCase;
 
 class CallbackTest extends TestCase
 {
-    /** @var Method\Callback */
-    private $callback;
+    private Callback $callback;
 
     protected function setUp(): void
     {
-        $this->callback = new Method\Callback();
+        $this->callback = new Callback();
     }
 
     public function testClassShouldBeNullByDefault(): void
@@ -107,7 +106,7 @@ class CallbackTest extends TestCase
             'class'  => 'Foo',
             'method' => 'bar',
         ];
-        $callback = new Method\Callback($options);
+        $callback = new Callback($options);
         $test     = $callback->toArray();
         self::assertSame($options, $test);
     }

--- a/test/Method/CallbackTest.php
+++ b/test/Method/CallbackTest.php
@@ -26,38 +26,38 @@ class CallbackTest extends TestCase
 
     public function testClassShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->callback->getClass());
+        self::assertNull($this->callback->getClass());
     }
 
     public function testClassShouldBeMutable(): void
     {
-        $this->assertNull($this->callback->getClass());
+        self::assertNull($this->callback->getClass());
         $this->callback->setClass('Foo');
-        $this->assertEquals('Foo', $this->callback->getClass());
+        self::assertEquals('Foo', $this->callback->getClass());
     }
 
     public function testMethodShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->callback->getMethod());
+        self::assertNull($this->callback->getMethod());
     }
 
     public function testMethodShouldBeMutable(): void
     {
-        $this->assertNull($this->callback->getMethod());
+        self::assertNull($this->callback->getMethod());
         $this->callback->setMethod('foo');
-        $this->assertEquals('foo', $this->callback->getMethod());
+        self::assertEquals('foo', $this->callback->getMethod());
     }
 
     public function testFunctionShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->callback->getFunction());
+        self::assertNull($this->callback->getFunction());
     }
 
     public function testFunctionShouldBeMutable(): void
     {
-        $this->assertNull($this->callback->getFunction());
+        self::assertNull($this->callback->getFunction());
         $this->callback->setFunction('foo');
-        $this->assertEquals('foo', $this->callback->getFunction());
+        self::assertEquals('foo', $this->callback->getFunction());
     }
 
     public function testFunctionMayBeCallable(): void
@@ -66,19 +66,19 @@ class CallbackTest extends TestCase
             return true;
         };
         $this->callback->setFunction($callable);
-        $this->assertEquals($callable, $this->callback->getFunction());
+        self::assertEquals($callable, $this->callback->getFunction());
     }
 
     public function testTypeShouldBeAnEmptyStringByDefault(): void
     {
-        $this->assertNull($this->callback->getType());
+        self::assertNull($this->callback->getType());
     }
 
     public function testTypeShouldBeMutable(): void
     {
-        $this->assertNull($this->callback->getType());
+        self::assertNull($this->callback->getType());
         $this->callback->setType('instance');
-        $this->assertEquals('instance', $this->callback->getType());
+        self::assertEquals('instance', $this->callback->getType());
     }
 
     public function testSettingTypeShouldThrowExceptionWhenInvalidTypeProvided(): void
@@ -94,10 +94,10 @@ class CallbackTest extends TestCase
                        ->setMethod('bar')
                        ->setType('instance');
         $test = $this->callback->toArray();
-        $this->assertIsArray($test);
-        $this->assertEquals('Foo', $test['class']);
-        $this->assertEquals('bar', $test['method']);
-        $this->assertEquals('instance', $test['type']);
+        self::assertIsArray($test);
+        self::assertEquals('Foo', $test['class']);
+        self::assertEquals('bar', $test['method']);
+        self::assertEquals('instance', $test['type']);
     }
 
     public function testConstructorShouldSetStateFromOptions(): void
@@ -109,13 +109,13 @@ class CallbackTest extends TestCase
         ];
         $callback = new Method\Callback($options);
         $test     = $callback->toArray();
-        $this->assertSame($options, $test);
+        self::assertSame($options, $test);
     }
 
     public function testSettingFunctionShouldSetTypeAsFunction(): void
     {
-        $this->assertNull($this->callback->getType());
+        self::assertNull($this->callback->getType());
         $this->callback->setFunction('foo');
-        $this->assertEquals('function', $this->callback->getType());
+        self::assertEquals('function', $this->callback->getType());
     }
 }

--- a/test/Method/DefinitionTest.php
+++ b/test/Method/DefinitionTest.php
@@ -26,7 +26,7 @@ class DefinitionTest extends TestCase
 
     public function testCallbackShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->definition->getCallback());
+        self::assertNull($this->definition->getCallback());
     }
 
     public function testSetCallbackShouldAcceptMethodCallback(): void
@@ -34,7 +34,7 @@ class DefinitionTest extends TestCase
         $callback = new Method\Callback();
         $this->definition->setCallback($callback);
         $test = $this->definition->getCallback();
-        $this->assertSame($callback, $test);
+        self::assertSame($callback, $test);
     }
 
     public function testSetCallbackShouldAcceptArray(): void
@@ -45,51 +45,51 @@ class DefinitionTest extends TestCase
         ];
         $this->definition->setCallback($callback);
         $test = $this->definition->getCallback()->toArray();
-        $this->assertSame($callback, $test);
+        self::assertSame($callback, $test);
     }
 
     public function testMethodHelpShouldBeEmptyStringByDefault(): void
     {
-        $this->assertEquals('', $this->definition->getMethodHelp());
+        self::assertEquals('', $this->definition->getMethodHelp());
     }
 
     public function testMethodHelpShouldBeMutable(): void
     {
-        $this->assertEquals('', $this->definition->getMethodHelp());
+        self::assertEquals('', $this->definition->getMethodHelp());
         $this->definition->setMethodHelp('foo bar');
-        $this->assertEquals('foo bar', $this->definition->getMethodHelp());
+        self::assertEquals('foo bar', $this->definition->getMethodHelp());
     }
 
     public function testNameShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->definition->getName());
+        self::assertNull($this->definition->getName());
     }
 
     public function testNameShouldBeMutable(): void
     {
-        $this->assertNull($this->definition->getName());
+        self::assertNull($this->definition->getName());
         $this->definition->setName('foo.bar');
-        $this->assertEquals('foo.bar', $this->definition->getName());
+        self::assertEquals('foo.bar', $this->definition->getName());
     }
 
     public function testObjectShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->definition->getObject());
+        self::assertNull($this->definition->getObject());
     }
 
     public function testObjectShouldBeMutable(): void
     {
-        $this->assertNull($this->definition->getObject());
+        self::assertNull($this->definition->getObject());
         $object = new stdClass();
         $this->definition->setObject($object);
-        $this->assertEquals($object, $this->definition->getObject());
+        self::assertEquals($object, $this->definition->getObject());
     }
 
     public function testInvokeArgumentsShouldBeEmptyArrayByDefault(): void
     {
         $args = $this->definition->getInvokeArguments();
-        $this->assertIsArray($args);
-        $this->assertEmpty($args);
+        self::assertIsArray($args);
+        self::assertEmpty($args);
     }
 
     public function testInvokeArgumentsShouldBeMutable(): void
@@ -97,14 +97,14 @@ class DefinitionTest extends TestCase
         $this->testInvokeArgumentsShouldBeEmptyArrayByDefault();
         $args = ['foo', ['bar', 'baz'], new stdClass()];
         $this->definition->setInvokeArguments($args);
-        $this->assertSame($args, $this->definition->getInvokeArguments());
+        self::assertSame($args, $this->definition->getInvokeArguments());
     }
 
     public function testPrototypesShouldBeEmptyArrayByDefault(): void
     {
         $prototypes = $this->definition->getPrototypes();
-        $this->assertIsArray($prototypes);
-        $this->assertEmpty($prototypes);
+        self::assertIsArray($prototypes);
+        self::assertEmpty($prototypes);
     }
 
     public function testDefinitionShouldAllowAddingSinglePrototypes(): void
@@ -113,13 +113,13 @@ class DefinitionTest extends TestCase
         $prototype1 = new Method\Prototype();
         $this->definition->addPrototype($prototype1);
         $test = $this->definition->getPrototypes();
-        $this->assertSame($prototype1, $test[0]);
+        self::assertSame($prototype1, $test[0]);
 
         $prototype2 = new Method\Prototype();
         $this->definition->addPrototype($prototype2);
         $test = $this->definition->getPrototypes();
-        $this->assertSame($prototype1, $test[0]);
-        $this->assertSame($prototype2, $test[1]);
+        self::assertSame($prototype1, $test[0]);
+        self::assertSame($prototype2, $test[1]);
     }
 
     public function testDefinitionShouldAllowAddingMultiplePrototypes(): void
@@ -128,7 +128,7 @@ class DefinitionTest extends TestCase
         $prototype2 = new Method\Prototype();
         $prototypes = [$prototype1, $prototype2];
         $this->definition->addPrototypes($prototypes);
-        $this->assertSame($prototypes, $this->definition->getPrototypes());
+        self::assertSame($prototypes, $this->definition->getPrototypes());
     }
 
     public function testSetPrototypesShouldOverwriteExistingPrototypes(): void
@@ -138,9 +138,9 @@ class DefinitionTest extends TestCase
         $prototype1 = new Method\Prototype();
         $prototype2 = new Method\Prototype();
         $prototypes = [$prototype1, $prototype2];
-        $this->assertNotSame($prototypes, $this->definition->getPrototypes());
+        self::assertNotSame($prototypes, $this->definition->getPrototypes());
         $this->definition->setPrototypes($prototypes);
-        $this->assertSame($prototypes, $this->definition->getPrototypes());
+        self::assertSame($prototypes, $this->definition->getPrototypes());
     }
 
     public function testDefintionShouldSerializeToArray(): void
@@ -158,12 +158,12 @@ class DefinitionTest extends TestCase
                          ->setObject($object)
                          ->setInvokeArguments($invokeArgs);
         $test = $this->definition->toArray();
-        $this->assertEquals($name, $test['name']);
-        $this->assertEquals($callback, $test['callback']);
-        $this->assertEquals($prototypes, $test['prototypes']);
-        $this->assertEquals($methodHelp, $test['methodHelp']);
-        $this->assertEquals($object, $test['object']);
-        $this->assertEquals($invokeArgs, $test['invokeArguments']);
+        self::assertEquals($name, $test['name']);
+        self::assertEquals($callback, $test['callback']);
+        self::assertEquals($prototypes, $test['prototypes']);
+        self::assertEquals($methodHelp, $test['methodHelp']);
+        self::assertEquals($object, $test['object']);
+        self::assertEquals($invokeArgs, $test['invokeArguments']);
     }
 
     public function testPassingOptionsToConstructorShouldSetObjectState(): void
@@ -178,11 +178,11 @@ class DefinitionTest extends TestCase
         ];
         $definition = new Method\Definition($options);
         $test       = $definition->toArray();
-        $this->assertEquals($options['name'], $test['name']);
-        $this->assertEquals($options['callback'], $test['callback']);
-        $this->assertEquals($options['prototypes'], $test['prototypes']);
-        $this->assertEquals($options['methodHelp'], $test['methodHelp']);
-        $this->assertEquals($options['object'], $test['object']);
-        $this->assertEquals($options['invokeArguments'], $test['invokeArguments']);
+        self::assertEquals($options['name'], $test['name']);
+        self::assertEquals($options['callback'], $test['callback']);
+        self::assertEquals($options['prototypes'], $test['prototypes']);
+        self::assertEquals($options['methodHelp'], $test['methodHelp']);
+        self::assertEquals($options['object'], $test['object']);
+        self::assertEquals($options['invokeArguments'], $test['invokeArguments']);
     }
 }

--- a/test/Method/DefinitionTest.php
+++ b/test/Method/DefinitionTest.php
@@ -10,18 +10,19 @@ declare(strict_types=1);
 
 namespace LaminasTest\Server\Method;
 
-use Laminas\Server\Method;
+use Laminas\Server\Method\Callback;
+use Laminas\Server\Method\Definition;
+use Laminas\Server\Method\Prototype;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 class DefinitionTest extends TestCase
 {
-    /** @var Method\Definition */
-    private $definition;
+    private Definition $definition;
 
     protected function setUp(): void
     {
-        $this->definition = new Method\Definition();
+        $this->definition = new Definition();
     }
 
     public function testCallbackShouldBeNullByDefault(): void
@@ -31,7 +32,7 @@ class DefinitionTest extends TestCase
 
     public function testSetCallbackShouldAcceptMethodCallback(): void
     {
-        $callback = new Method\Callback();
+        $callback = new Callback();
         $this->definition->setCallback($callback);
         $test = $this->definition->getCallback();
         self::assertSame($callback, $test);
@@ -110,12 +111,12 @@ class DefinitionTest extends TestCase
     public function testDefinitionShouldAllowAddingSinglePrototypes(): void
     {
         $this->testPrototypesShouldBeEmptyArrayByDefault();
-        $prototype1 = new Method\Prototype();
+        $prototype1 = new Prototype();
         $this->definition->addPrototype($prototype1);
         $test = $this->definition->getPrototypes();
         self::assertSame($prototype1, $test[0]);
 
-        $prototype2 = new Method\Prototype();
+        $prototype2 = new Prototype();
         $this->definition->addPrototype($prototype2);
         $test = $this->definition->getPrototypes();
         self::assertSame($prototype1, $test[0]);
@@ -124,8 +125,8 @@ class DefinitionTest extends TestCase
 
     public function testDefinitionShouldAllowAddingMultiplePrototypes(): void
     {
-        $prototype1 = new Method\Prototype();
-        $prototype2 = new Method\Prototype();
+        $prototype1 = new Prototype();
+        $prototype2 = new Prototype();
         $prototypes = [$prototype1, $prototype2];
         $this->definition->addPrototypes($prototypes);
         self::assertSame($prototypes, $this->definition->getPrototypes());
@@ -135,8 +136,8 @@ class DefinitionTest extends TestCase
     {
         $this->testDefinitionShouldAllowAddingMultiplePrototypes();
 
-        $prototype1 = new Method\Prototype();
-        $prototype2 = new Method\Prototype();
+        $prototype1 = new Prototype();
+        $prototype2 = new Prototype();
         $prototypes = [$prototype1, $prototype2];
         self::assertNotSame($prototypes, $this->definition->getPrototypes());
         $this->definition->setPrototypes($prototypes);
@@ -176,7 +177,7 @@ class DefinitionTest extends TestCase
             'object'          => new stdClass(),
             'invokeArguments' => ['foo', ['bar', 'baz']],
         ];
-        $definition = new Method\Definition($options);
+        $definition = new Definition($options);
         $test       = $definition->toArray();
         self::assertEquals($options['name'], $test['name']);
         self::assertEquals($options['callback'], $test['callback']);

--- a/test/Method/ParameterTest.php
+++ b/test/Method/ParameterTest.php
@@ -10,17 +10,16 @@ declare(strict_types=1);
 
 namespace LaminasTest\Server\Method;
 
-use Laminas\Server\Method;
+use Laminas\Server\Method\Parameter;
 use PHPUnit\Framework\TestCase;
 
 class ParameterTest extends TestCase
 {
-    /** @var Method\Parameter */
-    private $parameter;
+    private Parameter $parameter;
 
     protected function setUp(): void
     {
-        $this->parameter = new Method\Parameter();
+        $this->parameter = new Parameter();
     }
 
     public function testDefaultValueShouldBeNullByDefault(): void
@@ -123,7 +122,7 @@ class ParameterTest extends TestCase
             'defaultValue' => $defaultValue,
             'description'  => $description,
         ];
-        $parameter    = new Method\Parameter($options);
+        $parameter    = new Parameter($options);
         $test         = $parameter->toArray();
         self::assertEquals($options, $test);
     }

--- a/test/Method/ParameterTest.php
+++ b/test/Method/ParameterTest.php
@@ -25,65 +25,65 @@ class ParameterTest extends TestCase
 
     public function testDefaultValueShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->parameter->getDefaultValue());
+        self::assertNull($this->parameter->getDefaultValue());
     }
 
     public function testDefaultValueShouldBeMutable(): void
     {
-        $this->assertNull($this->parameter->getDefaultValue());
+        self::assertNull($this->parameter->getDefaultValue());
         $this->parameter->setDefaultValue('foo');
-        $this->assertSame('foo', $this->parameter->getDefaultValue());
+        self::assertSame('foo', $this->parameter->getDefaultValue());
     }
 
     public function testDescriptionShouldBeEmptyStringByDefault(): void
     {
-        $this->assertSame('', $this->parameter->getDescription());
+        self::assertSame('', $this->parameter->getDescription());
     }
 
     public function testDescriptionShouldBeMutable(): void
     {
         $message = 'This is a description';
-        $this->assertSame('', $this->parameter->getDescription());
+        self::assertSame('', $this->parameter->getDescription());
         $this->parameter->setDescription($message);
-        $this->assertSame($message, $this->parameter->getDescription());
+        self::assertSame($message, $this->parameter->getDescription());
     }
 
     public function testNameShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->parameter->getName());
+        self::assertNull($this->parameter->getName());
     }
 
     public function testNameShouldBeMutable(): void
     {
         $name = 'foo';
-        $this->assertNull($this->parameter->getName());
+        self::assertNull($this->parameter->getName());
         $this->parameter->setName($name);
-        $this->assertSame($name, $this->parameter->getName());
+        self::assertSame($name, $this->parameter->getName());
     }
 
     public function testParameterShouldBeRequiredByDefault(): void
     {
-        $this->assertFalse($this->parameter->isOptional());
+        self::assertFalse($this->parameter->isOptional());
     }
 
     public function testParameterShouldAllowBeingOptional(): void
     {
-        $this->assertFalse($this->parameter->isOptional());
+        self::assertFalse($this->parameter->isOptional());
         $this->parameter->setOptional(true);
-        $this->assertTrue($this->parameter->isOptional());
+        self::assertTrue($this->parameter->isOptional());
     }
 
     public function testTypeShouldBeMixedByDefault(): void
     {
-        $this->assertEquals('mixed', $this->parameter->getType());
+        self::assertEquals('mixed', $this->parameter->getType());
     }
 
     public function testTypeShouldBeMutable(): void
     {
         $type = 'string';
-        $this->assertEquals('mixed', $this->parameter->getType());
+        self::assertEquals('mixed', $this->parameter->getType());
         $this->parameter->setType($type);
-        $this->assertSame($type, $this->parameter->getType());
+        self::assertSame($type, $this->parameter->getType());
     }
 
     public function testParameterShouldSerializeToArray(): void
@@ -106,7 +106,7 @@ class ParameterTest extends TestCase
                         ->setDefaultValue($defaultValue)
                         ->setDescription($description);
         $test = $this->parameter->toArray();
-        $this->assertEquals($parameter, $test);
+        self::assertEquals($parameter, $test);
     }
 
     public function testConstructorShouldSetObjectStateFromPassedOptions(): void
@@ -125,6 +125,6 @@ class ParameterTest extends TestCase
         ];
         $parameter    = new Method\Parameter($options);
         $test         = $parameter->toArray();
-        $this->assertEquals($options, $test);
+        self::assertEquals($options, $test);
     }
 }

--- a/test/Method/PrototypeTest.php
+++ b/test/Method/PrototypeTest.php
@@ -26,21 +26,21 @@ class PrototypeTest extends TestCase
 
     public function testReturnTypeShouldBeVoidByDefault(): void
     {
-        $this->assertEquals('void', $this->prototype->getReturnType());
+        self::assertEquals('void', $this->prototype->getReturnType());
     }
 
     public function testReturnTypeShouldBeMutable(): void
     {
-        $this->assertEquals('void', $this->prototype->getReturnType());
+        self::assertEquals('void', $this->prototype->getReturnType());
         $this->prototype->setReturnType('string');
-        $this->assertEquals('string', $this->prototype->getReturnType());
+        self::assertEquals('string', $this->prototype->getReturnType());
     }
 
     public function testParametersShouldBeEmptyArrayByDefault(): void
     {
         $params = $this->prototype->getParameters();
-        $this->assertIsArray($params);
-        $this->assertEmpty($params);
+        self::assertIsArray($params);
+        self::assertEmpty($params);
     }
 
     public function testPrototypeShouldAllowAddingSingleParameters(): void
@@ -48,15 +48,15 @@ class PrototypeTest extends TestCase
         $this->testParametersShouldBeEmptyArrayByDefault();
         $this->prototype->addParameter('string');
         $params = $this->prototype->getParameters();
-        $this->assertIsArray($params);
-        $this->assertCount(1, $params);
-        $this->assertEquals('string', $params[0]);
+        self::assertIsArray($params);
+        self::assertCount(1, $params);
+        self::assertEquals('string', $params[0]);
 
         $this->prototype->addParameter('array');
         $params = $this->prototype->getParameters();
-        $this->assertCount(2, $params);
-        $this->assertEquals('string', $params[0]);
-        $this->assertEquals('array', $params[1]);
+        self::assertCount(2, $params);
+        self::assertEquals('string', $params[0]);
+        self::assertEquals('array', $params[1]);
     }
 
     public function testPrototypeShouldAllowAddingParameterObjects(): void
@@ -66,7 +66,7 @@ class PrototypeTest extends TestCase
             'name' => 'foo',
         ]);
         $this->prototype->addParameter($parameter);
-        $this->assertSame($parameter, $this->prototype->getParameter('foo'));
+        self::assertSame($parameter, $this->prototype->getParameter('foo'));
     }
 
     public function testPrototypeShouldAllowFetchingParameterByNameOrIndex(): void
@@ -78,9 +78,9 @@ class PrototypeTest extends TestCase
         $this->prototype->addParameter($parameter);
         $test1 = $this->prototype->getParameter('foo');
         $test2 = $this->prototype->getParameter(0);
-        $this->assertSame($test1, $test2);
-        $this->assertSame($parameter, $test1);
-        $this->assertSame($parameter, $test2);
+        self::assertSame($test1, $test2);
+        self::assertSame($parameter, $test1);
+        self::assertSame($parameter, $test2);
     }
 
     public function testPrototypeShouldAllowRetrievingParameterObjects(): void
@@ -88,7 +88,7 @@ class PrototypeTest extends TestCase
         $this->prototype->addParameters(['string', 'array']);
         $parameters = $this->prototype->getParameterObjects();
         foreach ($parameters as $parameter) {
-            $this->assertInstanceOf(Parameter::class, $parameter);
+            self::assertInstanceOf(Parameter::class, $parameter);
         }
     }
 
@@ -101,7 +101,7 @@ class PrototypeTest extends TestCase
         ];
         $this->prototype->addParameters($params);
         $test = $this->prototype->getParameters();
-        $this->assertSame($params, $test);
+        self::assertSame($params, $test);
     }
 
     public function testSetParametersShouldOverwriteParameters(): void
@@ -114,7 +114,7 @@ class PrototypeTest extends TestCase
         ];
         $this->prototype->setParameters($params);
         $test = $this->prototype->getParameters();
-        $this->assertSame($params, $test);
+        self::assertSame($params, $test);
     }
 
     public function testPrototypeShouldSerializeToArray(): void
@@ -128,8 +128,8 @@ class PrototypeTest extends TestCase
         $this->prototype->setReturnType($return)
                         ->setParameters($params);
         $test = $this->prototype->toArray();
-        $this->assertEquals($return, $test['returnType']);
-        $this->assertEquals($params, $test['parameters']);
+        self::assertEquals($return, $test['returnType']);
+        self::assertEquals($params, $test['parameters']);
     }
 
     public function testConstructorShouldSetObjectStateFromOptions(): void
@@ -144,6 +144,6 @@ class PrototypeTest extends TestCase
         ];
         $prototype = new Method\Prototype($options);
         $test      = $prototype->toArray();
-        $this->assertSame($options, $test);
+        self::assertSame($options, $test);
     }
 }

--- a/test/Method/PrototypeTest.php
+++ b/test/Method/PrototypeTest.php
@@ -10,18 +10,17 @@ declare(strict_types=1);
 
 namespace LaminasTest\Server\Method;
 
-use Laminas\Server\Method;
 use Laminas\Server\Method\Parameter;
+use Laminas\Server\Method\Prototype;
 use PHPUnit\Framework\TestCase;
 
 class PrototypeTest extends TestCase
 {
-    /** @var Method\Prototype */
-    private $prototype;
+    private Prototype $prototype;
 
     protected function setUp(): void
     {
-        $this->prototype = new Method\Prototype();
+        $this->prototype = new Prototype();
     }
 
     public function testReturnTypeShouldBeVoidByDefault(): void
@@ -61,7 +60,7 @@ class PrototypeTest extends TestCase
 
     public function testPrototypeShouldAllowAddingParameterObjects(): void
     {
-        $parameter = new Method\Parameter([
+        $parameter = new Parameter([
             'type' => 'string',
             'name' => 'foo',
         ]);
@@ -71,7 +70,7 @@ class PrototypeTest extends TestCase
 
     public function testPrototypeShouldAllowFetchingParameterByNameOrIndex(): void
     {
-        $parameter = new Method\Parameter([
+        $parameter = new Parameter([
             'type' => 'string',
             'name' => 'foo',
         ]);
@@ -142,7 +141,7 @@ class PrototypeTest extends TestCase
                 'struct',
             ],
         ];
-        $prototype = new Method\Prototype($options);
+        $prototype = new Prototype($options);
         $test      = $prototype->toArray();
         self::assertSame($options, $test);
     }

--- a/test/Reflection/NodeTest.php
+++ b/test/Reflection/NodeTest.php
@@ -20,21 +20,21 @@ class NodeTest extends TestCase
     public function testConstructor(): void
     {
         $node = new Node('string');
-        $this->assertInstanceOf(Node::class, $node);
-        $this->assertEquals('string', $node->getValue());
-        $this->assertNull($node->getParent());
+        self::assertInstanceOf(Node::class, $node);
+        self::assertEquals('string', $node->getValue());
+        self::assertNull($node->getParent());
         $children = $node->getChildren();
-        $this->assertEmpty($children);
+        self::assertEmpty($children);
 
         $child = new Node('array', $node);
-        $this->assertInstanceOf(Node::class, $child);
-        $this->assertEquals('array', $child->getValue());
-        $this->assertEquals($node, $child->getParent());
+        self::assertInstanceOf(Node::class, $child);
+        self::assertEquals('array', $child->getValue());
+        self::assertEquals($node, $child->getParent());
         $children = $child->getChildren();
-        $this->assertEmpty($children);
+        self::assertEmpty($children);
 
         $children = $node->getChildren();
-        $this->assertEquals($child, $children[0]);
+        self::assertEquals($child, $children[0]);
     }
 
     public function testSetParent(): void
@@ -44,7 +44,7 @@ class NodeTest extends TestCase
 
         $child->setParent($parent);
 
-        $this->assertEquals($parent, $child->getParent());
+        self::assertEquals($parent, $child->getParent());
     }
 
     public function testCreateChild(): void
@@ -52,9 +52,9 @@ class NodeTest extends TestCase
         $parent = new Node('string');
         $child  = $parent->createChild('array');
 
-        $this->assertEquals($parent, $child->getParent());
+        self::assertEquals($parent, $child->getParent());
         $children = $parent->getChildren();
-        $this->assertEquals($child, $children[0]);
+        self::assertEquals($child, $children[0]);
     }
 
     public function testAttachChild(): void
@@ -63,9 +63,9 @@ class NodeTest extends TestCase
         $child  = new Node('array');
 
         $parent->attachChild($child);
-        $this->assertEquals($parent, $child->getParent());
+        self::assertEquals($parent, $child->getParent());
         $children = $parent->getChildren();
-        $this->assertEquals($child, $children[0]);
+        self::assertEquals($child, $children[0]);
     }
 
     public function testGetChildren(): void
@@ -78,18 +78,18 @@ class NodeTest extends TestCase
         foreach ($children as $c) {
             $types[] = $c->getValue();
         }
-        $this->assertIsArray($children);
-        $this->assertCount(1, $children, var_export($types, true));
-        $this->assertEquals($child, $children[0]);
+        self::assertIsArray($children);
+        self::assertCount(1, $children, var_export($types, true));
+        self::assertEquals($child, $children[0]);
     }
 
     public function testHasChildren(): void
     {
         $parent = new Node('string');
 
-        $this->assertFalse($parent->hasChildren());
+        self::assertFalse($parent->hasChildren());
         $parent->createChild('array');
-        $this->assertTrue($parent->hasChildren());
+        self::assertTrue($parent->hasChildren());
     }
 
     public function testGetParent(): void
@@ -97,22 +97,22 @@ class NodeTest extends TestCase
         $parent = new Node('string');
         $child  = $parent->createChild('array');
 
-        $this->assertNull($parent->getParent());
-        $this->assertEquals($parent, $child->getParent());
+        self::assertNull($parent->getParent());
+        self::assertEquals($parent, $child->getParent());
     }
 
     public function testGetValue(): void
     {
         $parent = new Node('string');
-        $this->assertEquals('string', $parent->getValue());
+        self::assertEquals('string', $parent->getValue());
     }
 
     public function testSetValue(): void
     {
         $parent = new Node('string');
-        $this->assertEquals('string', $parent->getValue());
+        self::assertEquals('string', $parent->getValue());
         $parent->setValue('array');
-        $this->assertEquals('array', $parent->getValue());
+        self::assertEquals('array', $parent->getValue());
     }
 
     public function testGetEndPoints(): void
@@ -141,7 +141,7 @@ class NodeTest extends TestCase
             'child2grand2great2',
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $test,
             $endPointsArray,
             'Test was [' . var_export($test, true) . ']; endPoints were [' . var_export($endPointsArray, true) . ']'

--- a/test/Reflection/PrototypeTest.php
+++ b/test/Reflection/PrototypeTest.php
@@ -19,14 +19,13 @@ use ReflectionClass;
 
 class PrototypeTest extends TestCase
 {
-    /** @var Prototype */
-    protected $r;
+    protected Prototype $r;
 
     /** @var ReflectionParameter[] */
-    protected $parametersRaw;
+    protected array $parametersRaw = [];
 
     /** @var ReflectionParameter[] */
-    protected $parameters;
+    protected array $parameters = [];
 
     protected function setUp(): void
     {

--- a/test/Reflection/PrototypeTest.php
+++ b/test/Reflection/PrototypeTest.php
@@ -53,7 +53,7 @@ class PrototypeTest extends TestCase
 
     public function testConstructWorks(): void
     {
-        $this->assertInstanceOf(Prototype::class, $this->r);
+        self::assertInstanceOf(Prototype::class, $this->r);
     }
 
     public function testConstructionThrowsExceptionOnInvalidParam(): void
@@ -65,7 +65,7 @@ class PrototypeTest extends TestCase
 
     public function testGetReturnType(): void
     {
-        $this->assertEquals('void', $this->r->getReturnType());
+        self::assertEquals('void', $this->r->getReturnType());
     }
 
     public function testGetParameters(): void
@@ -73,11 +73,11 @@ class PrototypeTest extends TestCase
         $r = new Prototype($this->r->getReturnValue(), $this->parameters);
         $p = $r->getParameters();
 
-        $this->assertIsArray($p);
+        self::assertIsArray($p);
         foreach ($p as $parameter) {
-            $this->assertInstanceOf(ReflectionParameter::class, $parameter);
+            self::assertInstanceOf(ReflectionParameter::class, $parameter);
         }
 
-        $this->assertEquals($this->parameters, $p);
+        self::assertEquals($this->parameters, $p);
     }
 }

--- a/test/Reflection/ReflectionClassTest.php
+++ b/test/Reflection/ReflectionClassTest.php
@@ -25,31 +25,31 @@ class ReflectionClassTest extends TestCase
     public function testConstructor(): void
     {
         $r = new Reflection\ReflectionClass(new PhpReflectionClass(Reflection::class));
-        $this->assertInstanceOf(ReflectionClass::class, $r);
-        $this->assertEquals('', $r->getNamespace());
+        self::assertInstanceOf(ReflectionClass::class, $r);
+        self::assertEquals('', $r->getNamespace());
 
         $methods = $r->getMethods();
-        $this->assertIsArray($methods);
+        self::assertIsArray($methods);
         foreach ($methods as $m) {
-            $this->assertInstanceOf(ReflectionMethod::class, $m);
+            self::assertInstanceOf(ReflectionMethod::class, $m);
         }
 
         $r = new Reflection\ReflectionClass(new PhpReflectionClass(Reflection::class), 'namespace');
-        $this->assertEquals('namespace', $r->getNamespace());
+        self::assertEquals('namespace', $r->getNamespace());
     }
 
     public function testMethodOverloading(): void
     {
         $r = new Reflection\ReflectionClass(new PhpReflectionClass(Reflection::class));
-        $this->assertIsString($r->getName());
-        $this->assertEquals(Reflection::class, $r->getName());
+        self::assertIsString($r->getName());
+        self::assertEquals(Reflection::class, $r->getName());
     }
 
     public function testGetSet(): void
     {
         $r         = new Reflection\ReflectionClass(new PhpReflectionClass(Reflection::class));
         $r->system = true;
-        $this->assertTrue($r->system);
+        self::assertTrue($r->system);
     }
 
     public function testGetMethods(): void
@@ -57,25 +57,25 @@ class ReflectionClassTest extends TestCase
         $r = new Reflection\ReflectionClass(new PhpReflectionClass(Reflection::class));
 
         $methods = $r->getMethods();
-        $this->assertIsArray($methods);
+        self::assertIsArray($methods);
         foreach ($methods as $m) {
-            $this->assertInstanceOf(ReflectionMethod::class, $m);
+            self::assertInstanceOf(ReflectionMethod::class, $m);
         }
     }
 
     public function testGetNamespace(): void
     {
         $r = new Reflection\ReflectionClass(new PhpReflectionClass(Reflection::class));
-        $this->assertEquals('', $r->getNamespace());
+        self::assertEquals('', $r->getNamespace());
         $r->setNamespace('namespace');
-        $this->assertEquals('namespace', $r->getNamespace());
+        self::assertEquals('namespace', $r->getNamespace());
     }
 
     public function testSetNamespaceSetsEmptyStringToNull(): void
     {
         $r = new Reflection\ReflectionClass(new PhpReflectionClass(Reflection::class));
         $r->setNamespace('');
-        $this->assertNull($r->getNamespace());
+        self::assertNull($r->getNamespace());
     }
 
     public function testSetNamespaceThrowsInvalidArgumentException(): void
@@ -91,12 +91,12 @@ class ReflectionClassTest extends TestCase
         $s = serialize($r);
         $u = unserialize($s);
 
-        $this->assertInstanceOf(ReflectionClass::class, $u);
-        $this->assertEquals('', $u->getNamespace());
-        $this->assertEquals($r->getName(), $u->getName());
+        self::assertInstanceOf(ReflectionClass::class, $u);
+        self::assertEquals('', $u->getNamespace());
+        self::assertEquals($r->getName(), $u->getName());
         $rMethods = $r->getMethods();
         $uMethods = $r->getMethods();
 
-        $this->assertCount(count($rMethods), $uMethods);
+        self::assertCount(count($rMethods), $uMethods);
     }
 }

--- a/test/Reflection/ReflectionFunctionTest.php
+++ b/test/Reflection/ReflectionFunctionTest.php
@@ -26,21 +26,21 @@ class ReflectionFunctionTest extends TestCase
     {
         $function = new ReflectionFunction('\LaminasTest\Server\Reflection\function1');
         $r        = new Reflection\ReflectionFunction($function);
-        $this->assertInstanceOf(Reflection\ReflectionFunction::class, $r);
-        $this->assertInstanceOf(AbstractFunction::class, $r);
+        self::assertInstanceOf(Reflection\ReflectionFunction::class, $r);
+        self::assertInstanceOf(AbstractFunction::class, $r);
         $params = $r->getParameters();
 
         $r = new Reflection\ReflectionFunction($function, 'namespace');
-        $this->assertEquals('namespace', $r->getNamespace());
+        self::assertEquals('namespace', $r->getNamespace());
 
         $argv = ['string1', 'string2'];
         $r    = new Reflection\ReflectionFunction($function, 'namespace', $argv);
-        $this->assertIsArray($r->getInvokeArguments());
-        $this->assertEquals($argv, $r->getInvokeArguments());
+        self::assertIsArray($r->getInvokeArguments());
+        self::assertEquals($argv, $r->getInvokeArguments());
 
         $prototypes = $r->getPrototypes();
-        $this->assertIsArray($prototypes);
-        $this->assertNotEmpty($prototypes);
+        self::assertIsArray($prototypes);
+        self::assertNotEmpty($prototypes);
     }
 
     public function testPropertyOverloading(): void
@@ -49,16 +49,16 @@ class ReflectionFunctionTest extends TestCase
         $r        = new Reflection\ReflectionFunction($function);
 
         $r->system = true;
-        $this->assertTrue($r->system);
+        self::assertTrue($r->system);
     }
 
     public function testNamespace(): void
     {
         $function = new ReflectionFunction('\LaminasTest\Server\Reflection\function1');
         $r        = new Reflection\ReflectionFunction($function, 'namespace');
-        $this->assertEquals('namespace', $r->getNamespace());
+        self::assertEquals('namespace', $r->getNamespace());
         $r->setNamespace('framework');
-        $this->assertEquals('framework', $r->getNamespace());
+        self::assertEquals('framework', $r->getNamespace());
     }
 
     public function testSetNamespaceSetsEmptyStringToNull(): void
@@ -66,7 +66,7 @@ class ReflectionFunctionTest extends TestCase
         $function = new ReflectionFunction('\LaminasTest\Server\Reflection\function1');
         $r        = new Reflection\ReflectionFunction($function, 'namespace');
         $r->setNamespace('');
-        $this->assertNull($r->getNamespace());
+        self::assertNull($r->getNamespace());
     }
 
     public function testSetNamespaceThrowsInvalidArgumentException(): void
@@ -81,9 +81,9 @@ class ReflectionFunctionTest extends TestCase
     {
         $function = new ReflectionFunction('\LaminasTest\Server\Reflection\function1');
         $r        = new Reflection\ReflectionFunction($function);
-        $this->assertStringContainsString('function for reflection', $r->getDescription());
+        self::assertStringContainsString('function for reflection', $r->getDescription());
         $r->setDescription('Testing setting descriptions');
-        $this->assertEquals('Testing setting descriptions', $r->getDescription());
+        self::assertEquals('Testing setting descriptions', $r->getDescription());
     }
 
     public function testGetPrototypes(): void
@@ -92,11 +92,11 @@ class ReflectionFunctionTest extends TestCase
         $r        = new Reflection\ReflectionFunction($function);
 
         $prototypes = $r->getPrototypes();
-        $this->assertIsArray($prototypes);
-        $this->assertCount(4, $prototypes);
+        self::assertIsArray($prototypes);
+        self::assertCount(4, $prototypes);
 
         foreach ($prototypes as $p) {
-            $this->assertInstanceOf(Prototype::class, $p);
+            self::assertInstanceOf(Prototype::class, $p);
         }
     }
 
@@ -106,12 +106,12 @@ class ReflectionFunctionTest extends TestCase
         $r        = new Reflection\ReflectionFunction($function);
 
         $prototypes = $r->getPrototypes();
-        $this->assertIsArray($prototypes);
-        $this->assertNotEmpty($prototypes);
-        $this->assertCount(1, $prototypes);
+        self::assertIsArray($prototypes);
+        self::assertNotEmpty($prototypes);
+        self::assertCount(1, $prototypes);
 
         foreach ($prototypes as $p) {
-            $this->assertInstanceOf(Prototype::class, $p);
+            self::assertInstanceOf(Prototype::class, $p);
         }
     }
 
@@ -120,13 +120,13 @@ class ReflectionFunctionTest extends TestCase
         $function = new ReflectionFunction('\LaminasTest\Server\Reflection\function1');
         $r        = new Reflection\ReflectionFunction($function);
         $args     = $r->getInvokeArguments();
-        $this->assertIsArray($args);
-        $this->assertCount(0, $args);
+        self::assertIsArray($args);
+        self::assertCount(0, $args);
 
         $argv = ['string1', 'string2'];
         $r    = new Reflection\ReflectionFunction($function, null, $argv);
         $args = $r->getInvokeArguments();
-        $this->assertEquals($argv, $args);
+        self::assertEquals($argv, $args);
     }
 
     public function testClassWakeup(): void
@@ -135,8 +135,8 @@ class ReflectionFunctionTest extends TestCase
         $r        = new Reflection\ReflectionFunction($function);
         $s        = serialize($r);
         $u        = unserialize($s);
-        $this->assertInstanceOf(Reflection\ReflectionFunction::class, $u);
-        $this->assertEquals('', $u->getNamespace());
+        self::assertInstanceOf(Reflection\ReflectionFunction::class, $u);
+        self::assertEquals('', $u->getNamespace());
     }
 
     public function testMultipleWhitespaceBetweenDoctagsAndTypes(): void
@@ -145,15 +145,15 @@ class ReflectionFunctionTest extends TestCase
         $r        = new Reflection\ReflectionFunction($function);
 
         $prototypes = $r->getPrototypes();
-        $this->assertIsArray($prototypes);
-        $this->assertNotEmpty($prototypes);
-        $this->assertCount(1, $prototypes);
+        self::assertIsArray($prototypes);
+        self::assertNotEmpty($prototypes);
+        self::assertCount(1, $prototypes);
 
         $proto  = $prototypes[0];
         $params = $proto->getParameters();
-        $this->assertIsArray($params);
-        $this->assertCount(1, $params);
-        $this->assertEquals('string', $params[0]->getType());
+        self::assertIsArray($params);
+        self::assertCount(1, $params);
+        self::assertEquals('string', $params[0]->getType());
     }
 
     public function testParameterReflectionShouldReturnTypeAndVarnameAndDescription(): void
@@ -165,7 +165,7 @@ class ReflectionFunctionTest extends TestCase
         $prototype  = $prototypes[0];
         $params     = $prototype->getParameters();
         $param      = $params[0];
-        $this->assertStringContainsString('Some description', $param->getDescription(), var_export($param, true));
+        self::assertStringContainsString('Some description', $param->getDescription(), var_export($param, true));
     }
 }
 

--- a/test/Reflection/ReflectionMethodTest.php
+++ b/test/Reflection/ReflectionMethodTest.php
@@ -36,11 +36,11 @@ class ReflectionMethodTest extends TestCase
     public function testConstructor(): void
     {
         $r = new Reflection\ReflectionMethod($this->class, $this->method);
-        $this->assertInstanceOf(ReflectionMethod::class, $r);
-        $this->assertInstanceOf(AbstractFunction::class, $r);
+        self::assertInstanceOf(ReflectionMethod::class, $r);
+        self::assertInstanceOf(AbstractFunction::class, $r);
 
         $r = new Reflection\ReflectionMethod($this->class, $this->method, 'namespace');
-        $this->assertEquals('namespace', $r->getNamespace());
+        self::assertEquals('namespace', $r->getNamespace());
     }
 
     public function testGetDeclaringClass(): void
@@ -49,7 +49,7 @@ class ReflectionMethodTest extends TestCase
 
         $class = $r->getDeclaringClass();
 
-        $this->assertEquals($this->class, $class);
+        self::assertEquals($this->class, $class);
     }
 
     public function testClassWakeup(): void
@@ -58,10 +58,10 @@ class ReflectionMethodTest extends TestCase
         $s = serialize($r);
         $u = unserialize($s);
 
-        $this->assertInstanceOf(ReflectionMethod::class, $u);
-        $this->assertInstanceOf(AbstractFunction::class, $u);
-        $this->assertEquals($r->getName(), $u->getName());
-        $this->assertEquals($r->getDeclaringClass()->getName(), $u->getDeclaringClass()->getName());
+        self::assertInstanceOf(ReflectionMethod::class, $u);
+        self::assertInstanceOf(AbstractFunction::class, $u);
+        self::assertEquals($r->getName(), $u->getName());
+        self::assertEquals($r->getDeclaringClass()->getName(), $u->getDeclaringClass()->getName());
     }
 
     public function testMethodDocBlockFromInterface(): void

--- a/test/Reflection/ReflectionMethodTest.php
+++ b/test/Reflection/ReflectionMethodTest.php
@@ -13,24 +13,26 @@ namespace LaminasTest\Server\Reflection;
 use Laminas\Server\Reflection;
 use Laminas\Server\Reflection\AbstractFunction;
 use Laminas\Server\Reflection\Node;
+use Laminas\Server\Reflection\ReflectionClass;
 use Laminas\Server\Reflection\ReflectionMethod;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
+use ReflectionClass as PhpReflectionClass;
+use ReflectionMethod as PhpReflectionMethod;
 
 use function serialize;
 use function unserialize;
 
 class ReflectionMethodTest extends TestCase
 {
-    protected $classRaw;
-    protected $class;
-    protected $method;
+    protected PhpReflectionClass $classRaw;
+    protected ReflectionClass $class;
+    protected PhpReflectionMethod $method;
 
     protected function setUp(): void
     {
-        $this->classRaw = new ReflectionClass(Reflection::class);
+        $this->classRaw = new PhpReflectionClass(Reflection::class);
         $this->method   = $this->classRaw->getMethod('reflectClass');
-        $this->class    = new Reflection\ReflectionClass($this->classRaw);
+        $this->class    = new ReflectionClass($this->classRaw);
     }
 
     public function testConstructor(): void
@@ -66,11 +68,11 @@ class ReflectionMethodTest extends TestCase
 
     public function testMethodDocBlockFromInterface(): void
     {
-        $reflectionClass  = new ReflectionClass(TestAsset\ReflectionMethodTestInstance::class);
+        $reflectionClass  = new PhpReflectionClass(TestAsset\ReflectionMethodTestInstance::class);
         $reflectionMethod = $reflectionClass->getMethod('testMethod');
 
         $laminasReflectionMethod = new Reflection\ReflectionMethod(
-            new Reflection\ReflectionClass($reflectionClass),
+            new ReflectionClass($reflectionClass),
             $reflectionMethod
         );
         [$prototype]             = $laminasReflectionMethod->getPrototypes();
@@ -82,11 +84,11 @@ class ReflectionMethodTest extends TestCase
 
     public function testMethodDocBlockFromParent(): void
     {
-        $reflectionClass  = new ReflectionClass(TestAsset\ReflectionMethodNode::class);
+        $reflectionClass  = new PhpReflectionClass(TestAsset\ReflectionMethodNode::class);
         $reflectionMethod = $reflectionClass->getMethod('setParent');
 
         $laminasReflectionMethod = new Reflection\ReflectionMethod(
-            new Reflection\ReflectionClass($reflectionClass),
+            new ReflectionClass($reflectionClass),
             $reflectionMethod
         );
         $prototypes              = $laminasReflectionMethod->getPrototypes();

--- a/test/Reflection/ReflectionParameterTest.php
+++ b/test/Reflection/ReflectionParameterTest.php
@@ -30,7 +30,7 @@ class ReflectionParameterTest extends TestCase
         $parameter = $this->getParameter();
 
         $reflection = new ReflectionParameter($parameter);
-        $this->assertInstanceOf(ReflectionParameter::class, $reflection);
+        self::assertInstanceOf(ReflectionParameter::class, $reflection);
     }
 
     public function testMethodOverloading(): void
@@ -38,34 +38,34 @@ class ReflectionParameterTest extends TestCase
         $r = new Reflection\ReflectionParameter($this->getParameter());
 
         // just test a few call proxies...
-        $this->assertIsBool($r->allowsNull());
-        $this->assertIsBool($r->isOptional());
+        self::assertIsBool($r->allowsNull());
+        self::assertIsBool($r->isOptional());
     }
 
     public function testGetSetType(): void
     {
         $r = new Reflection\ReflectionParameter($this->getParameter());
-        $this->assertEquals('mixed', $r->getType());
+        self::assertEquals('mixed', $r->getType());
 
         $r->setType('string');
-        $this->assertEquals('string', $r->getType());
+        self::assertEquals('string', $r->getType());
     }
 
     public function testGetDescription(): void
     {
         $r = new Reflection\ReflectionParameter($this->getParameter());
-        $this->assertEquals('', $r->getDescription());
+        self::assertEquals('', $r->getDescription());
 
         $r->setDescription('parameter description');
-        $this->assertEquals('parameter description', $r->getDescription());
+        self::assertEquals('parameter description', $r->getDescription());
     }
 
     public function testSetPosition(): void
     {
         $r = new Reflection\ReflectionParameter($this->getParameter());
-        $this->assertEquals(null, $r->getPosition());
+        self::assertEquals(null, $r->getPosition());
 
         $r->setPosition(3);
-        $this->assertEquals(3, $r->getPosition());
+        self::assertEquals(3, $r->getPosition());
     }
 }

--- a/test/Reflection/ReflectionReturnValueTest.php
+++ b/test/Reflection/ReflectionReturnValueTest.php
@@ -19,16 +19,16 @@ class ReflectionReturnValueTest extends TestCase
     public function testConstructor(): void
     {
         $obj = new Reflection\ReflectionReturnValue();
-        $this->assertInstanceOf(ReflectionReturnValue::class, $obj);
+        self::assertInstanceOf(ReflectionReturnValue::class, $obj);
     }
 
     public function testGetType(): void
     {
         $obj = new Reflection\ReflectionReturnValue();
-        $this->assertEquals('mixed', $obj->getType());
+        self::assertEquals('mixed', $obj->getType());
 
         $obj->setType('array');
-        $this->assertEquals('array', $obj->getType());
+        self::assertEquals('array', $obj->getType());
     }
 
     public function testSetType(): void
@@ -36,16 +36,16 @@ class ReflectionReturnValueTest extends TestCase
         $obj = new Reflection\ReflectionReturnValue();
 
         $obj->setType('array');
-        $this->assertEquals('array', $obj->getType());
+        self::assertEquals('array', $obj->getType());
     }
 
     public function testGetDescription(): void
     {
         $obj = new Reflection\ReflectionReturnValue('string', 'Some description');
-        $this->assertEquals('Some description', $obj->getDescription());
+        self::assertEquals('Some description', $obj->getDescription());
 
         $obj->setDescription('New Description');
-        $this->assertEquals('New Description', $obj->getDescription());
+        self::assertEquals('New Description', $obj->getDescription());
     }
 
     public function testSetDescription(): void
@@ -53,6 +53,6 @@ class ReflectionReturnValueTest extends TestCase
         $obj = new Reflection\ReflectionReturnValue();
 
         $obj->setDescription('New Description');
-        $this->assertEquals('New Description', $obj->getDescription());
+        self::assertEquals('New Description', $obj->getDescription());
     }
 }

--- a/test/ReflectionTest.php
+++ b/test/ReflectionTest.php
@@ -20,10 +20,10 @@ class ReflectionTest extends TestCase
     public function testReflectClass(): void
     {
         $reflection = Reflection::reflectClass(TestAsset\ReflectionTestClass::class);
-        $this->assertInstanceOf(ReflectionClass::class, $reflection);
+        self::assertInstanceOf(ReflectionClass::class, $reflection);
 
         $reflection = Reflection::reflectClass(new TestAsset\ReflectionTestClass());
-        $this->assertInstanceOf(ReflectionClass::class, $reflection);
+        self::assertInstanceOf(ReflectionClass::class, $reflection);
     }
 
     public function testReflectClassThrowsExceptionOnInvalidParameter(): void
@@ -36,7 +36,7 @@ class ReflectionTest extends TestCase
     public function testReflectClass2(): void
     {
         $reflection = Reflection::reflectClass(TestAsset\ReflectionTestClass::class, [], 'zsr');
-        $this->assertEquals('zsr', $reflection->getNamespace());
+        self::assertEquals('zsr', $reflection->getNamespace());
     }
 
     public function testReflectFunctionThrowsExceptionOnInvalidFunction(): void
@@ -56,6 +56,6 @@ class ReflectionTest extends TestCase
 //    public function testReflectFunction2(): void
 //    {
 //        $reflection = Reflection::reflectFunction('LaminasTest\Server\TestAsset\reflectionTestFunction', null, 'zsr');
-//        $this->assertEquals('zsr', $reflection->getNamespace());
+//        self::assertEquals('zsr', $reflection->getNamespace());
 //    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes
| New Feature   | yes
| QA            | yes

### Description

This package relies on parsing DocBlock @param and @return values to reflect method signatures. With PHP's support for type declarations method signatures can be reflected from these declarations.

Preparatory for this change, this PR add property type declarations where applicable.

Cases where either mixed types are being used or actual intended type is not fully clear, code has not changed. I need to investigate these cases to fully understand their purpose before making any (most likely BC-breaking) changes. That will be done in a separate PR.