### PR TITLE
Fix for deprecated use of ReflectionParameter::isArray() on PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.phpunit.result.cache
+/.phpcs-cache
+/.phpunit.result.cache
 /clover.xml
 /composer.lock
 /coveralls-upload.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#18](https://github.com/laminas/laminas-server/pull/18) fixes detection of array function and method parameters on PHP 8.
 
 ## 2.9.0 - 2020-11-23
 

--- a/src/Reflection/AbstractFunction.php
+++ b/src/Reflection/AbstractFunction.php
@@ -285,7 +285,12 @@ abstract class AbstractFunction
         $paramDesc     = [];
         if (empty($paramTags)) {
             foreach ($parameters as $param) {
-                $paramTypesTmp[] = [($param->isArray()) ? 'array' : 'mixed'];
+                if (PHP_VERSION_ID >= 80000) {
+                    $isArray = ($type = $param->getType()) instanceof \ReflectionNamedType && $type->getName() === 'array';
+                } else {
+                    $isArray = $param->isArray();
+                }
+                $paramTypesTmp[] = [$isArray ? 'array' : 'mixed'];
                 $paramDesc[]     = '';
             }
         } else {

--- a/src/Reflection/AbstractFunction.php
+++ b/src/Reflection/AbstractFunction.php
@@ -13,6 +13,8 @@ use ReflectionClass as PhpReflectionClass;
 use ReflectionFunction as PhpReflectionFunction;
 use ReflectionFunctionAbstract;
 use ReflectionMethod as PhpReflectionMethod;
+use ReflectionNamedType;
+use ReflectionParameter as PhpReflectionParameter;
 
 /**
  * Function/Method Reflection
@@ -285,12 +287,7 @@ abstract class AbstractFunction
         $paramDesc     = [];
         if (empty($paramTags)) {
             foreach ($parameters as $param) {
-                if (PHP_VERSION_ID >= 80000) {
-                    $isArray = ($type = $param->getType()) instanceof \ReflectionNamedType && $type->getName() === 'array';
-                } else {
-                    $isArray = $param->isArray();
-                }
-                $paramTypesTmp[] = [$isArray ? 'array' : 'mixed'];
+                $paramTypesTmp[] = [$this->paramIsArray($param) ? 'array' : 'mixed'];
                 $paramDesc[]     = '';
             }
         } else {
@@ -489,5 +486,15 @@ abstract class AbstractFunction
         } else {
             $this->reflection = new PhpReflectionFunction($this->name);
         }
+    }
+
+    private function paramIsArray(PhpReflectionParameter $param): bool
+    {
+        if (PHP_VERSION_ID >= 80000) {
+            $type = $param->getType();
+            return $type instanceof ReflectionNamedType && $type->getName() === 'array';
+        }
+
+        return $param->isArray();
     }
 }

--- a/src/Reflection/AbstractFunction.php
+++ b/src/Reflection/AbstractFunction.php
@@ -287,6 +287,8 @@ abstract class AbstractFunction
         $paramDesc     = [];
         if (empty($paramTags)) {
             foreach ($parameters as $param) {
+                // Suppressing, because false positive
+                /** @psalm-suppress TooManyArguments **/
                 $paramTypesTmp[] = [$this->paramIsArray($param) ? 'array' : 'mixed'];
                 $paramDesc[]     = '';
             }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

PHP 8 deprecates the use of `ReflectionParameter::isArray()`. Since 2.9.0 announced support for PHP 8 a fix should be applied.
