### PR TITLE
Fixed error when receiving null $argv in Reflection::reflectClass/reflectFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
+- [#19](https://github.com/laminas/laminas-server/pull/19) fixes a scenario whereby calling `Reflection::reflectionFunction()` or `new ReflectMethod()` with `null` or otherwise invalid `$argv` arguments could lead to fatal errors. These methods now either validate or cast on all invalid values.
+
 - [#18](https://github.com/laminas/laminas-server/pull/18) fixes detection of array function and method parameters on PHP 8.
 
 ## 2.9.0 - 2020-11-23

--- a/src/Reflection.php
+++ b/src/Reflection.php
@@ -80,6 +80,6 @@ class Reflection
             throw new Reflection\Exception\InvalidArgumentException('Invalid argv argument passed to reflectFunction');
         }
 
-        return new ReflectionFunction(new \ReflectionFunction($function), $namespace, $argv);
+        return new ReflectionFunction(new \ReflectionFunction($function), $namespace, is_array($argv) ? $argv : []);
     }
 }

--- a/src/Reflection.php
+++ b/src/Reflection.php
@@ -60,7 +60,7 @@ class Reflection
      * may be provided as an array to $argv.
      *
      * @param string $function Function name
-     * @param  bool|array $argv Optional arguments to be used during the method call
+     * @param  null|bool|array $argv Optional arguments to be used during the method call
      * @param string $namespace Optional namespace with which to prefix the
      * function name (used for the signature key). Primarily to avoid
      * collisions, also for XmlRpc namespacing
@@ -76,10 +76,13 @@ class Reflection
             ));
         }
 
-        if ($argv && ! is_array($argv)) {
+        // Cast null or false values to empty array
+        $argv = in_array($argv, [false, null], true) ? [] : $argv;
+
+        if (! is_array($argv)) {
             throw new Reflection\Exception\InvalidArgumentException('Invalid argv argument passed to reflectFunction');
         }
 
-        return new ReflectionFunction(new \ReflectionFunction($function), $namespace, is_array($argv) ? $argv : []);
+        return new ReflectionFunction(new \ReflectionFunction($function), $namespace, $argv);
     }
 }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -73,7 +73,7 @@ class ReflectionClass
 
             if ($method->isPublic()) {
                 // Get signatures and description
-                $this->methods[] = new ReflectionMethod($this, $method, $this->getNamespace(), $argv);
+                $this->methods[] = new ReflectionMethod($this, $method, $this->getNamespace(), is_array($argv) ? $argv : []);
             }
         }
     }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -65,6 +65,8 @@ class ReflectionClass
         $this->name = $reflection->getName();
         $this->setNamespace($namespace);
 
+        $argv = is_array($argv) ? $argv : [];
+
         foreach ($reflection->getMethods() as $method) {
             // Don't aggregate magic methods
             if ('__' == substr($method->getName(), 0, 2)) {
@@ -73,7 +75,7 @@ class ReflectionClass
 
             if ($method->isPublic()) {
                 // Get signatures and description
-                $this->methods[] = new ReflectionMethod($this, $method, $this->getNamespace(), is_array($argv) ? $argv : []);
+                $this->methods[] = new ReflectionMethod($this, $method, $this->getNamespace(), $argv);
             }
         }
     }

--- a/test/Reflection/ReflectionClassTest.php
+++ b/test/Reflection/ReflectionClassTest.php
@@ -135,4 +135,39 @@ class ReflectionClassTest extends TestCase
 
         $this->assertCount(count($rMethods), $uMethods);
     }
+
+    /**
+     * @psalm-return array<string, array{0: mixed}>
+     */
+    public function nonArrayArgvValues(): array
+    {
+        return [
+            'null'          => [null],
+            'false'         => [false],
+            'true'          => [true],
+            'zero'          => [0],
+            'one'           => [1],
+            'floating zero' => [0.0],
+            'float'         => [1.1],
+            'string'        => ['string'],
+            'object'        => [(object) []],
+        ];
+    }
+
+    /**
+     * @dataProvider nonArrayArgvValues
+     * @param mixed $argv
+     */
+    public function testNonArrayArgvValuesResultInEmptyInvokationArgumentsToReflectedMethods($argv): void
+    {
+        // Suppressing, as we are validating
+        /** @psalm-suppress MixedAssignment */
+        $r = new Reflection\ReflectionClass(new \ReflectionClass(Reflection::class), null, $argv);
+
+        $methods = $r->getMethods();
+        foreach ($methods as $m) {
+            assert($m instanceof ReflectionMethod);
+            $this->assertSame([], $m->getInvokeArguments());
+        }
+    }
 }


### PR DESCRIPTION
…
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Given the loose typehints in `ReflectionClass` and `ReflectionMethod` it can happen that they receive `null` as the `$argv` parameter, leading to an error.

In practice this happened to me when using laminas-json-server which contains the following code with `$argv` defaulting to `null`:
```php
    public function setClass($class, $namespace = '', $argv = null)
    {
        if (2 < func_num_args()) {
            $argv = func_get_args();
            $argv = array_slice($argv, 2);
        }

        $reflection = Reflection::reflectClass($class, $argv, $namespace);

        foreach ($reflection->getMethods() as $method) {
            $definition = $this->_buildSignature($method, $class);
            $this->addMethodServiceMap($definition);
        }

        return $this;
    }
```

The code from `Laminas\Json\Server` contains its own bug given that `if (2 < func_num_args()) {` should more likely be `if (3 < func_num_args()) {`, but still it seems right to at least protect from such a situation in `laminas-server` as well.